### PR TITLE
Update RootNamespace and AssemblyName in nfproj

### DIFF
--- a/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch.nfproj
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch.nfproj
@@ -12,8 +12,8 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
-    <RootNamespace>MakoIoT.Device.Services.Logging.Sinks.SdCard</RootNamespace>
-    <AssemblyName>MakoIoT.Device.Services.Logging.Sinks.SdCard</AssemblyName>
+    <RootNamespace>MakoIoT.Device.Services.Logging.Sinks.Elasticsearch</RootNamespace>
+    <AssemblyName>MakoIoT.Device.Services.Logging.Sinks.Elasticsearch</AssemblyName>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />


### PR DESCRIPTION
The RootNamespace and AssemblyName in the nfproj file have been corrected. They were previously set to `MakoIoT.Device.Services.Logging.Sinks.SdCard`, and have now been updated to the correct value of `MakoIoT.Device.Services.Logging.Sinks.Elasticsearch`.