### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch.nfproj
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch.nfproj
@@ -23,7 +23,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.28.14340\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.29.40293\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -43,16 +43,16 @@
     <Reference Include="nanoFramework.System.Text">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.56.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.56\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.75\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.77.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.77\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.132.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.132\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.134.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.134\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731, processorArchitecture=MSIL">

--- a/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/packages.config
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.28.14340" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.29.40293" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.56" />
-  <package id="nanoFramework.System.Net" version="1.10.75" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.132" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.59" />
+  <package id="nanoFramework.System.Net" version="1.10.77" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.134" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Utilities.Invoker from 1.0.28.14340 to 1.0.29.40293</br>Bumps nanoFramework.System.IO.Streams from 1.1.56 to 1.1.59</br>Bumps nanoFramework.System.Net from 1.10.75 to 1.10.77</br>Bumps nanoFramework.System.Net.Http from 1.5.132 to 1.5.134</br>
[version update]

### :warning: This is an automated update. :warning:
