### PR TITLE
Update 9 NuGet dependencies

### DIFF
--- a/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch.nfproj
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch.nfproj
@@ -25,32 +25,32 @@
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.46.41501\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.31\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.63\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.67\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.91\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.94\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.42\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.192\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.193.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.193\lib\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/packages.config
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.Elasticsearch/packages.config
@@ -2,14 +2,14 @@
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.46.41501" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.31" />
-  <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.91" />
-  <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.192" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" />
+  <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.94" />
+  <package id="nanoFramework.System.Net" version="1.11.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.193" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.17.7 to 1.17.11</br>Bumps nanoFramework.DependencyInjection from 1.1.30 to 1.1.32</br>Bumps nanoFramework.Runtime.Events from 1.11.31 to 1.11.32</br>Bumps nanoFramework.System.Collections from 1.5.63 to 1.5.67</br>Bumps nanoFramework.System.IO.Streams from 1.1.91 to 1.1.94</br>Bumps nanoFramework.System.Net from 1.11.37 to 1.11.42</br>Bumps nanoFramework.System.Net.Http from 1.5.192 to 1.5.193</br>Bumps nanoFramework.System.Text from 1.3.36 to 1.3.42</br>Bumps nanoFramework.System.Threading from 1.1.50 to 1.1.52</br>
[version update]

### :warning: This is an automated update. :warning:
